### PR TITLE
Add 4.6.3 release

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,8 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: ['latest', '4.6.2', '4.6.2-alpine-glibc']
-    
+        tag:
+          - 'latest'
+          - '4.6.3'
+          - '4.6.3-alpine-glibc'
+          - '4.6.2'
+          - '4.6.2-alpine-glibc'
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
@@ -57,7 +62,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      
+
       - name: Image Release
         if: startsWith(github.ref, 'refs/tags/')
         run: |

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Sauce Connect Docker App lets you easily run [Sauce Connect Proxy](https://wiki.
 
 ## Supported tags
 
-- 4.6.2, 4.6.2-apline-glibc, latest
-- 4.5.4
+- 4.6.3, 4.6.3-alpine-glibc, latest
+- 4.6.2, 4.6.2-alpine-glibc, latest
 
 ## Running
 
@@ -107,5 +107,5 @@ Have a look into the GitHub Actions pipeline for [this repository](https://githu
 
 ## Supported tags
 
-- 4.6.2, 4.6.2-apline-glibc, latest
-- 4.5.4
+- 4.6.3, 4.6.3-alpine-glibc, latest
+- 4.6.2, 4.6.2-alpine-glibc, latest

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -4,8 +4,16 @@ const SERVICE_PORT = '22'
 const SERVICE_HOME = `/srv/${SERVICE_NAME}`
 const DIST_IMAGES = {
     'latest': {
-        version: '4.6.2',
+        version: '4.6.3',
         from: 'ubuntu:18.04'
+    },
+    '4.6.3': {
+        version: '4.6.3',
+        from: 'ubuntu:18.04'
+    },
+    '4.6.3-alpine-glibc': {
+        version: '4.6.3',
+        from: 'frolvlad/alpine-glibc'
     },
     '4.6.2': {
         version: '4.6.2',


### PR DESCRIPTION
Adding the 4.6.3 Sauce Connect release.

@christian-bromann

* Should I drop the 4.6.2 release?
* There are docs referring to 4.6.2 and 4.5.4, should those be updated as well?