### PR TITLE
Use latest debian

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,6 +23,8 @@ jobs:
       matrix:
         tag:
           - 'latest'
+          - '4.6.5'
+          - '4.6.5-alpine-glibc'            
           - '4.6.4'
           - '4.6.4-alpine-glibc'
           - '4.6.3'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Sauce Connect Docker App lets you easily run [Sauce Connect Proxy](https://wiki.
 
 ## Supported tags
 
-- 4.6.4, 4.6.4-alpine-glibc, latest
+- 4.6.5, 4.6.5-alpine-glibc, latest
+- 4.6.4, 4.6.4-alpine-glibc
 - 4.6.3, 4.6.3-alpine-glibc
 - 4.6.2, 4.6.2-alpine-glibc
 
@@ -108,6 +109,7 @@ Have a look into the GitHub Actions pipeline for [this repository](https://githu
 
 ## Supported tags
 
-- 4.6.4, 4.6.4-alpine-glibc, latest
+- 4.6.5, 4.6.5-alpine-glibc, latest
+- 4.6.4, 4.6.4-alpine-glibc
 - 4.6.3, 4.6.3-alpine-glibc
 - 4.6.2, 4.6.2-alpine-glibc

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -4,12 +4,20 @@ const SERVICE_PORT = '22'
 const SERVICE_HOME = `/srv/${SERVICE_NAME}`
 const DIST_IMAGES = {
     'latest': {
-        version: '4.6.4',
-        from: 'ubuntu:18.04'
+        version: '4.6.5',
+        from: 'ubuntu:20.04'
+    },
+    '4.6.5': {
+        version: '4.6.5',
+        from: 'ubuntu:20.04'
+    },
+    '4.6.5-alpine-glibc': {
+        version: '4.6.5',
+        from: 'frolvlad/alpine-glibc'
     },
     '4.6.4': {
         version: '4.6.4',
-        from: 'ubuntu:18.04'
+        from: 'ubuntu:20.04'
     },
     '4.6.4-alpine-glibc': {
         version: '4.6.4',
@@ -17,7 +25,7 @@ const DIST_IMAGES = {
     },
     '4.6.3': {
         version: '4.6.3',
-        from: 'ubuntu:18.04'
+        from: 'ubuntu:20.04'
     },
     '4.6.3-alpine-glibc': {
         version: '4.6.3',
@@ -25,7 +33,7 @@ const DIST_IMAGES = {
     },
     '4.6.2': {
         version: '4.6.2',
-        from: 'ubuntu:18.04'
+        from: 'ubuntu:20.04'
     },
     '4.6.2-alpine-glibc': {
         version: '4.6.2',


### PR DESCRIPTION
>A customer interested in using our SC docker container ran a security scan which uncovered several vulnerabilities that need to be addressed before they are willing to use the image - issues are related to following component versions used in the image  GoLang 1.13.5 and some unbuntu 18.04.7 libraries