### PR TITLE
SC logs to stdout

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,5 +1,8 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+---
+# This workflow will do a clean install of node dependencies,
+# build the source code and run tests across different versions of node
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: SC Docker tests pipeline
 
@@ -24,7 +27,7 @@ jobs:
         tag:
           - 'latest'
           - '4.6.5'
-          - '4.6.5-alpine-glibc'            
+          - '4.6.5-alpine-glibc'
           - '4.6.4'
           - '4.6.4-alpine-glibc'
           - '4.6.3'
@@ -45,14 +48,14 @@ jobs:
 
       - name: Start Sauce Connect
         run: |
+          cp test/sc-test.yaml /tmp/sc-test.yaml
           docker run \
             -e SAUCE_USERNAME=${{ secrets.SAUCE_USERNAME }} \
             -e SAUCE_ACCESS_KEY=${{ secrets.SAUCE_ACCESS_KEY }} \
             -v /tmp:/tmp \
             --network="host" \
             -t saucelabs/sauce-connect:${{ matrix.tag }} \
-            -f /tmp/sc.ready \
-            -v -l - \
+            -c /tmp/sc-test.yaml \
             -i sc-${{ matrix.tag }}-$GITHUB_RUN_NUMBER &
           ./test/wait-for-sc.sh
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,12 @@ Additional arguments may be specified as you would normally do with Sauce Connec
 
 ### Sauce Connect Setup Leveraging High Availability
 
-Our High Availability Sauce Connect Proxy Setup enables you to run tests using multiple Sauce Connect tunnels and run multiple tunnels grouped together as a tunnel pool, which will be treated as single tunnel. Pools are ideal for running 200 or more parallel tests (high concurrency) because tunnel capacity is limited by a single TCP Connection.
+Our High Availability Sauce Connect Proxy Setup enables you to run tests using multiple Sauce Connect
+tunnels and run multiple tunnels grouped together as a tunnel pool, which will be treated as single tunnel.
+Pools are ideal for running 200 or more parallel tests (high concurrency) because tunnel capacity is limited by a single TCP Connection.
 
-To run such pools it is important to apply the `--shared-tunnel --no-remove-colliding-tunnels` parameters to your command and start multiple container with the same tunnel identifier:
+To run such pools it is important to apply the `--no-remove-colliding-tunnels`
+parameters to your command and start multiple container with the same tunnel identifier:
 
 ```sh
 # tunnel #1
@@ -45,7 +48,6 @@ $ docker run \
     -e SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} \
     --network="host" \
     -it saucelabs/sauce-connect
-    --shared-tunnel \
     --no-remove-colliding-tunnels
     -i sc-tunnel-pool &
 
@@ -55,17 +57,17 @@ docker run \
     -e SAUCE_ACCESS_KEY=${SAUCE_ACCESS_KEY} \
     --network="host" \
     -it saucelabs/sauce-connect
-    --shared-tunnel \
     --no-remove-colliding-tunnels
     -i sc-tunnel-pool
 ```
 
-For more information on high availability Sauce Connect Proxy setup, please check out [the docs](https://wiki.saucelabs.com/display/DOCS/High+Availability+Sauce+Connect+Proxy+Setup).
+For more information on high availability Sauce Connect Proxy setup, please check out [the docs](https://docs.saucelabs.com/secure-connections/sauce-connect/setup-configuration/high-availability).
 
 ### Using SauceConnect Config file
 
 SauceConnect allows to define YAML [config file](./docs/sc-configuration/config.yaml) that will contain your configuration.
 YAML config file may contain username, access key, etc... See [SauceConnect documentation](https://docs.saucelabs.com/dev/cli/sauce-connect-proxy) for all the options.
+This Docker image comes with [a config file](./scripts/files/sc-default.yaml) but it could be replaced with a custom one.
 
 To use a predefined config file with the docker container:
 
@@ -121,7 +123,8 @@ If you want to run this Docker image as part of your CI/CD pipeline, you can run
 
 1. __Start Sauce Connect__
 
-   It is important that you mount a temporary folder so that `wait-for-sc.sh` can detect when Sauce Connect has launched. Also make sure that you set `--network="host"` to allow Sauce Connect to access your application in the host machine.
+   It is important that you mount a temporary folder so that `wait-for-sc.sh` can detect when Sauce Connect has launched.
+   Also make sure that you set `--network="host"` to allow Sauce Connect to access your application in the host machine.
    ```sh
    $ docker run \
        -e SAUCE_USERNAME=${SAUCE_USERNAME} \

--- a/scripts/files/entrypoint.sh
+++ b/scripts/files/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+SC_BIN=${SERVICE_HOME}/sc-${SERVICE_VERSION}-linux/bin/sc
+
+if [ "$1" != '--' ]; then
+  $SC_BIN "$@"
+else
+  shift
+  exec "$@"
+fi

--- a/scripts/files/sc-default.yaml
+++ b/scripts/files/sc-default.yaml
@@ -1,0 +1,4 @@
+---
+logfile: "-"
+se-port: 4445
+metrics-address: ":8032"

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -10,7 +10,8 @@ const { DIST_IMAGES, ...SERVICE_CONSTANTS } = require('./constants')
 const ROOT_DIR = path.join(__dirname, '..')
 const DIST_DIR = path.join(ROOT_DIR, 'dist')
 const DOCKERFILE_TPL = fs.readFileSync(path.join(__dirname, 'templates', 'Dockerfile.tpl.ejs'), 'utf8')
-const ENTRYPOINT_TPL = fs.readFileSync(path.join(__dirname, 'templates', 'entrypoint.tpl.ejs'), 'utf8')
+const ENTRYPOINT_SH = path.join(__dirname, 'files', 'entrypoint.sh')
+const SC_CONFIG_YAML = path.join(__dirname, 'files', 'sc-default.yaml')
 
 ;(() => {
     shelljs.mkdir(DIST_DIR)
@@ -26,11 +27,11 @@ const ENTRYPOINT_TPL = fs.readFileSync(path.join(__dirname, 'templates', 'entryp
         const buildArgs = { from, SERVICE_VERSION, ...SERVICE_CONSTANTS }
         const buildOpts = { delimiter: '?' }
         const dockerfile = ejs.render(DOCKERFILE_TPL, buildArgs, buildOpts)
-        const entrypoint = ejs.render(ENTRYPOINT_TPL, buildArgs, buildOpts)
 
         const imageDir = path.join(DIST_DIR, distName)
         shelljs.mkdir(imageDir)
         fs.writeFileSync(path.join(imageDir, 'Dockerfile'), dockerfile)
-        fs.writeFileSync(path.join(imageDir, 'entrypoint.sh'), entrypoint)
+        fs.copyFileSync(ENTRYPOINT_SH, path.join(imageDir, 'entrypoint.sh'))
+        fs.copyFileSync(SC_CONFIG_YAML, path.join(imageDir, 'sc.yaml'))
     }
 })()

--- a/scripts/templates/Dockerfile.tpl.ejs
+++ b/scripts/templates/Dockerfile.tpl.ejs
@@ -9,6 +9,7 @@ ENV SERVICE_VERSION=<?= SERVICE_VERSION ?>
 ENV SERVICE_HOST=<?= SERVICE_HOST ?>
 ENV SERVICE_PORT=<?= SERVICE_PORT ?>
 ENV SERVICE_HOME=<?= SERVICE_HOME ?>
+ENV SAUCE_CONFIG_FILE=/sc.yaml
 
 <? if (from.includes('ubuntu')) {?>
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -33,6 +34,7 @@ RUN ln -s ${SERVICE_HOME}/sc-${SERVICE_VERSION}-linux/bin/sc /sc
 <? } ?>
 
 COPY entrypoint.sh /
+COPY sc.yaml $SAUCE_CONFIG_FILE
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 4445

--- a/scripts/templates/entrypoint.tpl.ejs
+++ b/scripts/templates/entrypoint.tpl.ejs
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-${SERVICE_HOME}/sc-${SERVICE_VERSION}-linux/bin/sc $@

--- a/test/sc-test.yaml
+++ b/test/sc-test.yaml
@@ -1,0 +1,4 @@
+---
+logfile: "-"
+pidfile: /tmp/sc.ready
+verbose: 1


### PR DESCRIPTION
Resolves #15

## Changes

- Added /sc.yaml config file to the docker image. The config file contains `logfile: "-"`. `"-"` is a convenient shortcut to tell sc to log to stdout and not to file
- README is updated
-  github flow file is updated to use sc-test.yaml config file
- Added an option to the entrypoint script to run any arbitrary command if cmdline arg starts with `--`

## Notes

- Fixed inaccurate doc saying that for HA mode  `--shared-tunnel --no-remove-colliding-tunnels` options are needed. `--shared-tunnel` is used to share the tunnel within the same org, it has nothing to do with HA mode 