### PR TITLE
Link to dockerhub image page in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Sauce Connect Docker App lets you easily run [Sauce Connect Proxy](https://wiki.
 
 ## Running
 
-Before we can run the container you need to pull it from [Docker Hub](https://hub.docker.com/):
+Before we can run the container you need to pull it from [Docker Hub](https://hub.docker.com/r/saucelabs/sauce-connect):
 
 ```sh
 $ docker pull saucelabs/sauce-connect


### PR DESCRIPTION
I expected this link to go directly to the docker image page itself 🤷‍♀️ 