### PR TITLE
Updating Sauce Connect Proxy supported versions list 

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,14 +30,6 @@ jobs:
           - '4.7.1-alpine-glibc'
           - '4.7.0'
           - '4.7.0-alpine-glibc'
-          - '4.6.5'
-          - '4.6.5-alpine-glibc'
-          - '4.6.4'
-          - '4.6.4-alpine-glibc'
-          - '4.6.3'
-          - '4.6.3-alpine-glibc'
-          - '4.6.2'
-          - '4.6.2-alpine-glibc'
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,6 +32,8 @@ jobs:
           - '4.7.0-alpine-glibc'
           - '4.8.0-dev'
           - '4.8.0-dev-alpine-glibc'
+          - '4.8.0-dev-centos'
+          - '4.8.0-dev-suse-15'
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,6 +30,8 @@ jobs:
           - '4.7.1-alpine-glibc'
           - '4.7.0'
           - '4.7.0-alpine-glibc'
+          - '4.8.0-dev'
+          - '4.8.0-dev-alpine-glibc'
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -30,10 +30,10 @@ jobs:
           - '4.7.1-alpine-glibc'
           - '4.7.0'
           - '4.7.0-alpine-glibc'
-          - '4.8.0-dev'
-          - '4.8.0-dev-alpine-glibc'
-          - '4.8.0-dev-centos'
-          - '4.8.0-dev-suse-15'
+          - '4.8.0-beta'
+          - '4.8.0-beta-alpine-glibc'
+          - '4.8.0-beta-centos'
+          - '4.8.0-beta-suse-15'
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,8 +32,6 @@ jobs:
           - '4.7.0-alpine-glibc'
           - '4.8.0-beta'
           - '4.8.0-beta-alpine-glibc'
-          - '4.8.0-beta-centos'
-          - '4.8.0-beta-suse-15'
 
     steps:
       - name: Checkout Code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ $ npm run build
 All image distributions are defined in [`/scripts/constant.js`](https://github.com/saucelabs/sauce-connect-docker/blob/5591268e7ce7f00a7cf8bf82846ba065f30fbdb1/scripts/constants.js#L5). You can also build a specific dist by setting a `DIST_TAG` enviroment variable:
 
 ```sh
-DIST_TAG=4.6.2 npm run build
+DIST_TAG=4.7.1 npm run build
 ```
 
 You will see all flavors of this image being generated in the `dist` directory.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ Sauce Connect Docker App lets you easily run [Sauce Connect Proxy](https://docs.
 
 - 4.7.1, 4.7.1-alpine-glibc, latest
 - 4.7.0, 4.7.0-alpine-glibc
-- 4.6.5, 4.6.5-alpine-glibc
-- 4.6.4, 4.6.4-alpine-glibc
-- 4.6.3, 4.6.3-alpine-glibc
-- 4.6.2, 4.6.2-alpine-glibc
 
 ## Running
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Sauce Connect Docker App lets you easily run [Sauce Connect Proxy](https://docs.
 
 - 4.7.1, 4.7.1-alpine-glibc, latest
 - 4.7.0, 4.7.0-alpine-glibc
+- 4.6.5, 4.6.5-alpine-glibc
+- 4.6.4, 4.6.4-alpine-glibc
+- 4.6.3, 4.6.3-alpine-glibc
+- 4.6.2, 4.6.2-alpine-glibc
 
 ## Running
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -612,9 +612,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+      "version": "1.14.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.8.tgz",
+      "integrity": "sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA=="
     },
     "fs-constants": {
       "version": "1.0.0",

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -7,20 +7,20 @@ const DIST_IMAGES = {
         version: '4.7.1',
         from: 'ubuntu:20.04'
     },
-    '4.8.0-dev': {
-        version: '4.8.0-dev',
+    '4.8.0-beta': {
+        version: '4.8.0-beta',
         from: 'ubuntu:20.04'
     },
-    '4.8.0-dev-centos': {
-        version: '4.8.0-dev',
+    '4.8.0-beta-centos': {
+        version: '4.8.0-beta',
         from: 'centos:centos7'
     },
-    '4.8.0-dev-suse-15': {
-        version: '4.8.0-dev',
+    '4.8.0-beta-suse-15': {
+        version: '4.8.0-beta',
         from: 'opensuse/leap:15'
     },
-    '4.8.0-dev-alpine-glibc': {
-        version: '4.8.0-dev',
+    '4.8.0-beta-alpine-glibc': {
+        version: '4.8.0-beta',
         from: 'frolvlad/alpine-glibc'
     },
     '4.7.1': {

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -7,6 +7,14 @@ const DIST_IMAGES = {
         version: '4.7.1',
         from: 'ubuntu:20.04'
     },
+    '4.8.0-dev': {
+        version: '4.8.0-dev',
+        from: 'ubuntu:20.04'
+    },
+    '4.8.0-dev-alpine-glibc': {
+        version: '4.8.0-dev',
+        from: 'frolvlad/alpine-glibc'
+    },
     '4.7.1': {
         version: '4.7.1',
         from: 'ubuntu:20.04'

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -11,6 +11,14 @@ const DIST_IMAGES = {
         version: '4.8.0-dev',
         from: 'ubuntu:20.04'
     },
+    '4.8.0-dev-centos': {
+        version: '4.8.0-dev',
+        from: 'centos:centos7'
+    },
+    '4.8.0-dev-suse-15': {
+        version: '4.8.0-dev',
+        from: 'opensuse/leap:15'
+    },
     '4.8.0-dev-alpine-glibc': {
         version: '4.8.0-dev',
         from: 'frolvlad/alpine-glibc'

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -22,38 +22,6 @@ const DIST_IMAGES = {
     '4.7.0-alpine-glibc': {
         version: '4.7.0',
         from: 'frolvlad/alpine-glibc'
-    },
-    '4.6.5': {
-        version: '4.6.5',
-        from: 'ubuntu:20.04'
-    },
-    '4.6.5-alpine-glibc': {
-        version: '4.6.5',
-        from: 'frolvlad/alpine-glibc'
-    },
-    '4.6.4': {
-        version: '4.6.4',
-        from: 'ubuntu:20.04'
-    },
-    '4.6.4-alpine-glibc': {
-        version: '4.6.4',
-        from: 'frolvlad/alpine-glibc'
-    },
-    '4.6.3': {
-        version: '4.6.3',
-        from: 'ubuntu:20.04'
-    },
-    '4.6.3-alpine-glibc': {
-        version: '4.6.3',
-        from: 'frolvlad/alpine-glibc'
-    },
-    '4.6.2': {
-        version: '4.6.2',
-        from: 'ubuntu:20.04'
-    },
-    '4.6.2-alpine-glibc': {
-        version: '4.6.2',
-        from: 'frolvlad/alpine-glibc'
     }
 }
 const BUILD_ARGS = { SERVICE_NAME, SERVICE_HOST, SERVICE_PORT, SERVICE_HOME }

--- a/scripts/templates/Dockerfile.tpl.ejs
+++ b/scripts/templates/Dockerfile.tpl.ejs
@@ -15,6 +15,14 @@ ENV SAUCE_CONFIG_FILE=/sc.yaml
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 	ca-certificates \
 	wget
+<? } else if (from.includes('centos')){ ?>
+RUN yum -y update && yum install -y ca-certificates \
+    wget \
+    bash
+<? } else if (from.includes('suse')){ ?>
+RUN update-ca-certificates && zypper --non-interactive install wget \
+    tar \
+    gzip
 <? } else { ?>
 RUN apk update && \
     apk add ca-certificates && \


### PR DESCRIPTION
According to [Sauce Connect lifecycle information](https://docs.saucelabs.com/secure-connections/sauce-connect/installation/#version-lifecycle-information), all the 4.6.x versions will only get "Security & Major Bug Fixes only" starting from Mar. 31, 2022. 

Docker images for those versions will not be updated anymore (though they would still be available on dockerhub).

Also, adding SC v4.8.0-beta docker image