### PR TITLE
Resolves #43 - Adding configuration to 4.8.0 to use a legacy proxy

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -21,7 +21,7 @@ const DIST_IMAGES = {
     },
     '4.8.0-alpine-glibc': {
         version: '4.8.0',
-        from: 'frolvlad/alpine-glibc'
+        from: 'frolvlad/alpine-glibc:alpine-3.14_glibc-2.33'
     },
     '4.7.1': {
         version: '4.7.1',
@@ -29,7 +29,7 @@ const DIST_IMAGES = {
     },
     '4.7.1-alpine-glibc': {
         version: '4.7.1',
-        from: 'frolvlad/alpine-glibc'
+        from: 'frolvlad/alpine-glibc:alpine-3.14_glibc-2.33'
     },
     '4.7.0': {
         version: '4.7.0',
@@ -37,7 +37,7 @@ const DIST_IMAGES = {
     },
     '4.7.0-alpine-glibc': {
         version: '4.7.0',
-        from: 'frolvlad/alpine-glibc'
+        from: 'frolvlad/alpine-glibc:alpine-3.14_glibc-2.33'
     }
 }
 const BUILD_ARGS = { SERVICE_NAME, SERVICE_HOST, SERVICE_PORT, SERVICE_HOME }

--- a/scripts/templates/sc-default.tpl.ejs
+++ b/scripts/templates/sc-default.tpl.ejs
@@ -6,4 +6,5 @@ metrics-address: ":8032"
 extra-info: '{"runner": "docker"}'
 <?} else {?>metadata: "runner:docker"
 output-format: "text"
+experimental: "no-proxy"
 <?} -?>


### PR DESCRIPTION
It looks like a new built-in proxy doesn't behave the same way. Using [this flag](https://docs.saucelabs.com/dev/cli/sauce-connect-proxy/#--experimental) should disable the new implementation and revert to legacy behavior. The flag should be removed from the subsequent SC versions if they support SSE the same way as 4.7.1.

Also, the latest `frolvlad/alpine-glibc` is broken and causes:

```
Run cp test/sc-test.yaml /tmp/sc-test.yaml
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: __finite: symbol not found
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: makecontext: symbol not found
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: setcontext: symbol not found
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: __register_atfork: symbol not found
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: __rawmemchr: symbol not found
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: __strdup: symbol not found
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: __isnan: symbol not found
Error relocating /srv/saucelabs/sauce-connect/sc-4.8.0-linux/bin/sc: __isinf: symbol not found
```

fixing it by using `frolvlad/alpine-glibc:alpine-3.14_glibc-2.33` as a base image for alpine-based SC images.