### PR TITLE
Adding Ubuntu22.04-based docker image

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         tag:
           - 'latest'
+          - '4.8.1-ubuntu-22.04'
           - '4.8.1'
           - '4.8.1-alpine-glibc'
           - '4.8.0'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Sauce Connect Docker App lets you easily run [Sauce Connect Proxy](https://docs.
 
 ## Supported tags
 
-- 4.8.1, 4.8.1-alpine-glibc, latest
+- 4.8.1, 4.8.1-ubuntu-22.04, 4.8.1-alpine-glibc, latest
 - 4.8.0, 4.8.0-alpine-glibc
 - 4.7.1, 4.7.1-alpine-glibc
 - 4.7.0, 4.7.0-alpine-glibc

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -5,7 +5,11 @@ const SERVICE_HOME = `/srv/${SERVICE_NAME}`
 const DIST_IMAGES = {
     'latest': {
         version: '4.8.1',
-        from: 'ubuntu:20.04'
+        from: 'ubuntu:22.04'
+    },
+    '4.8.1-ubuntu-22.04': {
+        version: '4.8.1',
+        from: 'ubuntu:22.04'
     },
     '4.8.1': {
         version: '4.8.1',


### PR DESCRIPTION
Updating the latest tag to Ubuntu22.04-based image with [SC-4.8.1](https://changelog.saucelabs.com/en/sauce-connect-proxy-release-version-481)