### PR TITLE
Updating the sample Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ To use this chart
   2022-08-02 02:59:11.464 [8] [CLI] [info] Sauce Connect is up, you may start your tests.
   ```
 
+- Pod restart
+
+The `terminationGracePeriodSeconds` is set to 600 seconds to allow sufficient time for jobs using the Sauce Connect Proxy to finish.
+
 ## Quick reference
 
 - __Maintained by__: the [Open Source Program Office](https://opensource.saucelabs.com/) at Sauce Labs

--- a/chart/sauce-connect/templates/deployment.yaml
+++ b/chart/sauce-connect/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["/srv/saucelabs/sauce-connect/sc-{{ .Values.image.tag }}-linux/bin/sc"]
           env:
             - name: SAUCE_REST_URL
               value: {{ .Values.sauceApiUrl | quote }}
@@ -48,6 +49,8 @@ spec:
               value: {{ .Values.tunnelName | quote }}
             - name: SAUCE_TUNNEL_POOL
               value: {{ .Values.tunnelPool | quote }}
+            - name: SAUCE_VERBOSE
+              value: {{ .Values.sauceVerbose | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: status
@@ -68,8 +71,8 @@ spec:
             periodSeconds: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.nodeSelector }}
-      restartPolicy: Never
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/chart/sauce-connect/values.yaml
+++ b/chart/sauce-connect/values.yaml
@@ -6,12 +6,13 @@ replicaCount: 1
 image:
   repository: saucelabs/sauce-connect
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  # sauce-connect image tag (cannot use "latest" here, it has to be a Sauce Connect Proxy version)
+  tag: "4.8.2"
 
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+terminationGracePeriodSeconds: 600
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -26,30 +27,22 @@ podAnnotations:
   appGroup: sauceConnect
 
 podSecurityContext: {}
-  # fsGroup: 2000
-
 securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP
 
-resources: {}
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 200m
+    memory: 526Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 autoscaling:
   enabled: false
@@ -70,6 +63,7 @@ sauceUser: ""
 sauceApiKey: ""
 tunnelName: "sc-k8s-tunnel"
 tunnelPool: "true"
+sauceVerbose: 0
 
 # See https://docs.saucelabs.com/secure-connections/sauce-connect/proxy-tunnels/#configuring-status-server
 status:


### PR DESCRIPTION
Setting `terminationGracePeriodSeconds` to 600 seconds in the provided sample Helm chart.
This would allow giving Sauce Connect enough time to wait for jobs that use it to terminate gracefully.

For example:

```
$ kubectl delete pod <sc pod>
$ k logs <sc pod>
...
sauce-connect
sauce-connect  Got signal terminated.
sauce-connect  Cleaning up the tunnel connection to tunnel-123456.tunnels.us-west-1.saucelabs.com.
sauce-connect  Removing tunnel 12345678.
sauce-connect  Will wait for up to 5m0s for active jobs using this tunnel to finish.
sauce-connect  Note: Press CTRL-C again to shut down immediately.
sauce-connect  Note: If you do this, tests that are still running will fail.
sauce-connect  Number of jobs using tunnel: 1.
sauce-connect  Number of jobs using tunnel: 1.
....
sauce-connect  Number of jobs using tunnel: 1.
....
sauce-connect All jobs using the tunnel have finished.
sauce-connect Waiting for the connection to terminate...
sauce-connect Tunnel connection closed.
sauce-connect Tunnel shutdown reason: 'terminated'.
sauce-connect Goodbye.
```