### PR TITLE
Fix - Set replica count when autoscaling is true

### DIFF
--- a/chart/sauce-connect/templates/deployment.yaml
+++ b/chart/sauce-connect/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "sauce-connect.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if .Values.autoscaling.enabled }}
   replicas: {{ .Values.tunnelPoolSize }}
   {{- end }}
   selector:


### PR DESCRIPTION
When using these values, the number of replicas is not properly set to 3.
```
tunnelPoolSize: 3
autoscaling:
  enabled: true
```