### PR TITLE
fix: remove autoscaling value from the helm chart

### DIFF
--- a/chart/sauce-connect/templates/deployment.yaml
+++ b/chart/sauce-connect/templates/deployment.yaml
@@ -6,9 +6,7 @@ metadata:
   labels:
     {{- include "sauce-connect.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.tunnelPoolSize }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "sauce-connect.selectorLabels" . | nindent 6 }}

--- a/chart/sauce-connect/values.yaml
+++ b/chart/sauce-connect/values.yaml
@@ -43,9 +43,6 @@ resources:
     cpu: 100m
     memory: 128Mi
 
-autoscaling:
-  enabled: false
-
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
The `autoscaling` value was meant to be used to scale the SC pool during the increased load.
Since the scaling was never implemented, we'll stick to static replica size.