### PR TITLE
Replace SAUCE_USER with SAUCE_USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Example of configuring Sauce Connect Proxy using environment variables (the exam
 $ cat /tmp/sc.env
 SAUCE_REGION=eu-central
 SAUCE_API_KEY=<YOUR API KEY>
-SAUCE_USER=<YOUR USERNAME>
+SAUCE_USERNAME=<YOUR USERNAME>
 SAUCE_OUTPUT_FORMAT=text
 SAUCE_TUNNEL_POOL=true
 SAUCE_LOGFILE=-

--- a/examples/docker-compose-prometheus-grafana/README.md
+++ b/examples/docker-compose-prometheus-grafana/README.md
@@ -8,14 +8,14 @@ Set the following required Sauce Connect 5 environment variables, see details in
 
 - `SAUCE_REGION` - Sauce Labs region, one of us-west, eu-central, etc.
 - `SAUCE_TUNNEL_NAME` - Sauce Connect Tunnel Pool name
-- `SAUCE_USER` - Sauce Labs username
+- `SAUCE_USERNAME` - Sauce Labs username
 - `SAUCE_ACCESS_KEY` - Sauce Labs access key
 
 Set the following docker compose variables, see details in the [Docker Compose documentation](https://docs.docker.com/)
 - `--no-log-prefix` will configure Docker Compose to not prepend Sauce Connect Proxy stdout with the container name.
 
 ```sh
-SAUCE_USER=foo SAUCE_ACCESS_KEY=xxxx SAUCE_TUNNEL_NAME=sc-prom-grafana SAUCE_REGION=us-west docker-compose up --no-log-prefix
+SAUCE_USERNAME=foo SAUCE_ACCESS_KEY=xxxx SAUCE_TUNNEL_NAME=sc-prom-grafana SAUCE_REGION=us-west docker-compose up --no-log-prefix
 ```
 
 ## Sauce Connect Dashboard

--- a/examples/docker-compose-prometheus-grafana/docker-compose.yaml
+++ b/examples/docker-compose-prometheus-grafana/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     image: "saucelabs/sauce-connect:5.0"
     pull_policy: always
     environment:
-      SAUCE_USER: ${SAUCE_USER}
+      SAUCE_USERNAME: ${SAUCE_USERNAME}
       SAUCE_ACCESS_KEY: ${SAUCE_ACCESS_KEY}
       SAUCE_REGION: "${SAUCE_REGION:-us-west}"
       SAUCE_TUNNEL_NAME: "${SAUCE_TUNNEL_NAME:-sc-prom-grafana}"


### PR DESCRIPTION
SC5 uses the `SAUCE_USERNAME` environment variable and does not recognize `SAUCE_USER`.